### PR TITLE
Update agent definitions for workflow graph v2

### DIFF
--- a/.alcove/tasks/issue-greeter.yml
+++ b/.alcove/tasks/issue-greeter.yml
@@ -2,23 +2,8 @@ name: Issue Greeter
 description: Comments on new issues in alcove-testing with a friendly greeting
 prompt: |
   An issue was just opened or reopened on bmbouter/alcove-testing.
-
-  Use curl with the pre-configured environment variables to interact with GitHub:
-    - $GITHUB_API_URL is the API base URL (already set, use it as-is)
-    - $GITHUB_TOKEN is the auth token (already set)
-
-  Step 1: Fetch the latest open issue:
-    curl -s -H "Authorization: token $GITHUB_TOKEN" \
-      "$GITHUB_API_URL/repos/bmbouter/alcove-testing/issues?state=open&sort=created&direction=desc&per_page=1"
-
-  Step 2: Post a brief, friendly comment thanking the reporter:
-    curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
-      -H "Content-Type: application/json" \
-      -d @/tmp/comment.json \
-      "$GITHUB_API_URL/repos/bmbouter/alcove-testing/issues/ISSUE_NUMBER/comments"
-
-  Write the comment JSON to /tmp/comment.json first to avoid shell escaping issues.
-  Keep the comment short — 2-3 sentences max.
+  Post a brief, friendly comment (2-3 sentences) thanking the reporter.
+  Use the GitHub API with $GITHUB_TOKEN and $GITHUB_API_URL.
 repo: https://github.com/bmbouter/alcove-testing.git
 timeout: 120
 profiles:

--- a/.alcove/workflows/test-pipeline.yml
+++ b/.alcove/workflows/test-pipeline.yml
@@ -1,0 +1,13 @@
+name: Test Pipeline
+workflow:
+  - id: greet
+    type: agent
+    agent: Issue Greeter
+    trigger:
+      github:
+        events: [issues]
+        actions: [labeled]
+        labels: [test-pipeline]
+        repos: [bmbouter/alcove-testing]
+        delivery_mode: polling
+    outputs: [comment_posted]


### PR DESCRIPTION
## Summary
- Simplify issue-greeter.yml prompt by removing verbose curl command examples (the agent can use `gh` CLI through Gate and doesn't need shell escaping workarounds)
- Add `.alcove/workflows/test-pipeline.yml` — a single-step test workflow that triggers on the `test-pipeline` label, demonstrating the workflow graph v2 format for the syncer

## Test plan
- [ ] Verify the syncer picks up the new workflow definition
- [ ] Trigger the issue-greeter by opening an issue and confirm it still posts a greeting with the simplified prompt
- [ ] Apply the `test-pipeline` label to an issue and verify the workflow fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)