### PR TITLE
Add debug-env agent definition

### DIFF
--- a/.alcove/tasks/debug-env.yml
+++ b/.alcove/tasks/debug-env.yml
@@ -1,0 +1,7 @@
+name: Debug Environment Inspector
+description: Prints all Skiff environment variables with dummy token detection and secret masking. Manually trigger to diagnose credential or networking issues.
+executable:
+  url: file:///usr/local/bin/debug-env
+timeout: 60
+profiles:
+  - testing-readonly


### PR DESCRIPTION
Manually triggered agent that prints all Skiff environment variables with dummy token detection. Useful for diagnosing credential or networking issues.