### PR TITLE
Add Splunk Log Analyzer agent definition

### DIFF
--- a/.alcove/tasks/splunk-analyzer.yml
+++ b/.alcove/tasks/splunk-analyzer.yml
@@ -1,0 +1,21 @@
+name: Splunk Log Analyzer
+description: |
+  Analyzes Splunk logs for 5xx errors and drafts Jira issues.
+  Runs as a pre-compiled agent binary from GitHub Releases.
+
+executable:
+  url: https://github.com/pulp/pulp-service/releases/download/agent-splunk-20260414-e4c209e/agent-splunk
+  args: ["--model", "claude-opus-4-6"]
+  env:
+    SPLUNK_INSECURE_SKIP_VERIFY: "true"
+
+timeout: 1800
+
+credentials:
+  SPLUNK_TOKEN: splunk
+  JIRA_TOKEN: jira
+  VERTEX_SA_JSON: google-vertex
+
+schedule:
+  cron: "0 * * * *"
+  enabled: false


### PR DESCRIPTION
Mirrors the agent definition from pulp/pulp-service for testing. Schedule disabled by default.