### PR TITLE
Add two-step dev container pipeline with shared branch

### DIFF
--- a/.alcove/tasks/dev-container-doc-writer.yml
+++ b/.alcove/tasks/dev-container-doc-writer.yml
@@ -1,0 +1,24 @@
+name: Dev Container Doc Writer
+description: Adds documentation to Go code after a bug fix, uses dev container to verify tests still pass
+prompt: |
+  You are a documentation agent working on a shared branch with a previous agent.
+
+  IMPORTANT: A previous agent has already fixed a bug and pushed to a branch.
+  Check the Workflow Context above for the branch name. You MUST checkout that
+  branch before making any changes:
+    git fetch origin && git checkout <branch-name>
+
+  Your tasks:
+  1. Checkout the branch from the workflow context
+  2. Read test-data/go-project/main.go
+  3. Add package-level documentation and improve function comments
+  4. Run tests via the dev container to verify nothing is broken
+  5. Commit and push your documentation changes to the SAME branch
+  6. Write results to /tmp/alcove-outputs.json:
+     {"docs_added": "true", "tests_pass": "true"}
+repo: https://github.com/bmbouter/alcove-testing.git
+timeout: 300
+dev_container:
+  image: docker.io/library/golang:1.25
+profiles:
+  - testing-writer

--- a/.alcove/tasks/dev-container-go-test.yml
+++ b/.alcove/tasks/dev-container-go-test.yml
@@ -1,16 +1,22 @@
 name: Dev Container Go Test
-description: Uses a dev container to build and test a Go project, finds and fixes a bug
+description: Uses a dev container to fix a bug in a Go project, pushes to a branch
 prompt: |
   The Go project at test-data/go-project/ has a bug that causes test failures.
-  Find the bug, fix it, and verify the tests pass.
 
   IMPORTANT: Run all build and test commands via the dev container as described
   in CLAUDE.md. Do not run go commands directly.
 
-  Write results to /tmp/alcove-outputs.json with keys: test_result, bug_description, fix_applied.
+  Steps:
+  1. Create a new branch: git checkout -b dev-container-test-$(date +%s)
+  2. Find and fix the bug in the Go project
+  3. Verify tests pass via the dev container
+  4. Commit your fix and push the branch:
+     git add -A && git commit -m "Fix Add function bug" && git push origin HEAD
+  5. Write results to /tmp/alcove-outputs.json including the branch name:
+     {"test_result": "pass", "branch": "<your-branch-name>", "fix_applied": "description"}
 repo: https://github.com/bmbouter/alcove-testing.git
 timeout: 300
 dev_container:
   image: docker.io/library/golang:1.25
 profiles:
-  - testing-readonly
+  - testing-writer

--- a/.alcove/workflows/dev-container-test-pipeline.yml
+++ b/.alcove/workflows/dev-container-test-pipeline.yml
@@ -1,7 +1,18 @@
 name: Dev Container Test Pipeline
-description: End-to-end test of the dev container feature with a Go project
+description: Two-step pipeline demonstrating shared branch with dev containers
 
 workflow:
   - id: fix-bug
     type: agent
     agent: Dev Container Go Test
+    inputs:
+      branch: "dev-container-test"
+    outputs: [branch]
+
+  - id: add-docs
+    type: agent
+    agent: Dev Container Doc Writer
+    depends: "fix-bug.Succeeded"
+    inputs:
+      branch: "{{steps.fix-bug.outputs.branch}}"
+    outputs: [docs_added]


### PR DESCRIPTION
## Summary
- Add `dev-container-doc-writer.yml` agent that checks out a branch from workflow context, adds documentation to Go code, verifies tests via dev container, and pushes to the same branch
- Update `dev-container-go-test.yml` agent to create a uniquely-named branch, push its fix, and output the branch name via `/tmp/alcove-outputs.json`
- Update `dev-container-test-pipeline.yml` workflow to be a two-step pipeline where step 2 receives step 1's branch via `{{steps.fix-bug.outputs.branch}}` template expansion
- Switch both agents from `testing-readonly` to `testing-writer` profile (the readonly profile lacks `push_branch`)

## How it works
1. **fix-bug step**: Creates branch `dev-container-test-<timestamp>`, fixes the bug, pushes, outputs `{"branch": "<name>"}`
2. **add-docs step**: Receives branch name via workflow context, does `git fetch && git checkout <branch>`, adds docs, pushes to same branch

This demonstrates shared branch collaboration between workflow steps, where each step runs in a fresh Skiff container with a dev container.

## Test plan
- [ ] Run the workflow via Bridge and verify both steps complete
- [ ] Verify step 2 checks out step 1's branch (not main)
- [ ] Verify the resulting branch has both the bug fix commit and the documentation commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)