### PR TITLE
Update workflow actions to unified bridge names

### DIFF
--- a/.alcove/workflows/jira-to-gitlab-pipeline.yml
+++ b/.alcove/workflows/jira-to-gitlab-pipeline.yml
@@ -19,7 +19,7 @@ workflow:
 
   - id: create-mr
     type: bridge
-    action: create-mr
+    action: create-merge-request
     depends: "update-docs.Succeeded"
     inputs:
       project: hosted-pulp/pulp-docs
@@ -30,7 +30,7 @@ workflow:
 
   - id: await-pipeline
     type: bridge
-    action: await-pipeline
+    action: await-checks
     depends: "create-mr.Succeeded"
     inputs:
       project: hosted-pulp/pulp-docs
@@ -39,7 +39,7 @@ workflow:
 
   - id: post-lgtm
     type: bridge
-    action: post-note
+    action: comment
     depends: "await-pipeline.Succeeded"
     inputs:
       project: hosted-pulp/pulp-docs

--- a/.alcove/workflows/sdlc-pipeline.yml
+++ b/.alcove/workflows/sdlc-pipeline.yml
@@ -23,7 +23,7 @@ workflow:
 
   - id: create-pr
     type: bridge
-    action: create-pr
+    action: create-merge-request
     depends: "implement.Succeeded"
     inputs:
       repo: bmbouter/alcove-testing
@@ -33,7 +33,7 @@ workflow:
 
   - id: await-ci
     type: bridge
-    action: await-ci
+    action: await-checks
     depends: "create-pr.Succeeded || ci-fix.Succeeded"
     max_iterations: 4
     inputs:
@@ -91,7 +91,7 @@ workflow:
 
   - id: merge
     type: bridge
-    action: merge-pr
+    action: merge
     depends: "code-review.Succeeded && security-review.Succeeded"
     inputs:
       repo: bmbouter/alcove-testing


### PR DESCRIPTION
## Summary
- Replaces deprecated bridge action aliases with unified names in workflow YAML files
- `create-pr` -> `create-merge-request`, `await-ci` -> `await-checks`, `merge-pr` -> `merge`
- `create-mr` -> `create-merge-request`, `await-pipeline` -> `await-checks`, `post-note` -> `comment`
- Affects `sdlc-pipeline.yml` and `jira-to-gitlab-pipeline.yml`

## Test plan
- [ ] Verify workflows still trigger and execute correctly (old names are backward compatible aliases)
- [ ] Confirm only `action:` field values changed, no step IDs or depends expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)