### PR TITLE
Fix JIRA-to-GitLab workflow bugs

### DIFF
--- a/.alcove/agents/jira-docs-updater.yml
+++ b/.alcove/agents/jira-docs-updater.yml
@@ -12,10 +12,10 @@ prompt: |
   The change should be a single-line addition or modification to an existing
   markdown file in the repository. Keep it minimal and relevant to the issue.
 
-  Push your change to a new branch named after the JIRA issue key
-  (e.g., PULP-1234-docs-update).
+  Push your change to a branch named {{trigger.issue_key}}-docs-update-YYYYMMDD-HHMMSS
+  (use the current date/time for uniqueness, e.g., PULP-1234-docs-update-20260421-153042).
 
-  Output: {"branch": "PULP-XXXX-docs-update", "file_changed": "path/to/file.md"}
+  Output: {"branch": "<the branch name you pushed>", "file_changed": "path/to/file.md"}
 
 repos:
   - name: pulp-docs
@@ -29,4 +29,4 @@ outputs:
   - file_changed
 
 profiles:
-  - testing-writer
+  - gitlab-pulp-docs-writer

--- a/.alcove/security-profiles/gitlab-pulp-docs-writer.yml
+++ b/.alcove/security-profiles/gitlab-pulp-docs-writer.yml
@@ -1,0 +1,13 @@
+name: gitlab-pulp-docs-writer
+display_name: GitLab Pulp Docs Writer
+description: Clone and push branches to hosted-pulp/pulp-docs on GitLab
+tools:
+  gitlab:
+    rules:
+      - repos: ["hosted-pulp/pulp-docs"]
+        operations:
+          - clone
+          - read_contents
+          - read_commits
+          - read_branches
+          - push_branch


### PR DESCRIPTION
## Summary

- **Branch name collision fix:** The jira-docs-updater agent prompt now instructs the agent to include a YYYYMMDD-HHMMSS timestamp in the branch name (e.g., `PULP-1234-docs-update-20260421-153042`), preventing "Another MR already exists" errors when the same JIRA issue triggers multiple workflow runs.
- **GitLab security profile:** Added `gitlab-pulp-docs-writer` security profile with clone/read/push permissions for `hosted-pulp/pulp-docs` on GitLab, replacing the GitHub-only `testing-writer` profile that the agent incorrectly referenced.

## Test plan

- [ ] Trigger the JIRA-to-GitLab pipeline twice for the same JIRA issue and verify both runs create distinct branches and MRs
- [ ] Verify the agent syncs successfully with the new `gitlab-pulp-docs-writer` profile (no "unknown profile" errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)