### PR TITLE
Add back test fixture security profiles for CI

### DIFF
--- a/.alcove/security-profiles/testing-readonly.yml
+++ b/.alcove/security-profiles/testing-readonly.yml
@@ -1,0 +1,10 @@
+name: testing-readonly
+display_name: Testing Read Only
+description: Minimal profile for CI testing
+tools:
+  github:
+    rules:
+      - repos: ["*"]
+        operations:
+          - clone
+          - read_issues

--- a/.alcove/security-profiles/testing-writer.yml
+++ b/.alcove/security-profiles/testing-writer.yml
@@ -1,0 +1,11 @@
+name: testing-writer
+display_name: Testing Writer
+description: Minimal write profile for CI testing
+tools:
+  github:
+    rules:
+      - repos: ["*"]
+        operations:
+          - clone
+          - read_issues
+          - create_comment


### PR DESCRIPTION
CI tests expect testing-readonly and testing-writer profiles.