### PR TITLE
Remove hardcoded JIRA_USERNAME from splunk-analyzer

### DIFF
--- a/.alcove/agents/splunk-analyzer.yml
+++ b/.alcove/agents/splunk-analyzer.yml
@@ -10,7 +10,6 @@ executable:
     SPLUNK_INSECURE_SKIP_VERIFY: "true"
     SPLUNK_URL: "https://rhcorporate.splunkcloud.com:8089"
     JIRA_URL: "https://redhat.atlassian.net"
-    JIRA_USERNAME: "bmbouter@redhat.com"
     ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-core-pe-eng-claude"
     CLOUD_ML_REGION: "us-east5"
 


### PR DESCRIPTION
JIRA credentials now use composite email:api_token format, so the username is embedded in the JIRA_API_TOKEN credential.

ref: https://github.com/pulp/pulp-service/pull/1164
ref: https://redhat.atlassian.net/browse/PULP-1671